### PR TITLE
fix null pointer crash on missing icon option

### DIFF
--- a/app/src/main/java/de/kaiserdragon/iconrequest/helper/DrawableHelper.java
+++ b/app/src/main/java/de/kaiserdragon/iconrequest/helper/DrawableHelper.java
@@ -42,6 +42,9 @@ public class DrawableHelper {
     }
 
     public static Bitmap getBitmapFromDrawable(Drawable drawable) {
+        if (drawable == null) {
+            return null;
+        }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && drawable instanceof AdaptiveIconDrawable) {
             return new AdaptiveIcon()
                     .setDrawable((AdaptiveIconDrawable) drawable)


### PR DESCRIPTION
Hi,

currently the app crashes when selecting the missing icon option with a null pointer exception.
I've added a simple null check, so it can keep going. Tbh i don't know why would try to load an icon if is missing 🤔 but this way it doesn't crash